### PR TITLE
Stop HTML from being rendered in the admin section

### DIFF
--- a/comments/services/CommentsService.php
+++ b/comments/services/CommentsService.php
@@ -216,8 +216,8 @@ class CommentsService extends BaseApplicationComponent
             $html = '<div class="comment-block">';
             $html .= '<span class="status ' . $context['element']->status . '"></span>';
             $html .= '<a href="' . $context['element']->getCpEditUrl() . '">';
-            $html .= '<span class="username">' . $userName . '</span>';
-            $html .= '<small>' . $context['element']->getExcerpt(0, 100) . '</small></a>';
+            $html .= '<span class="username">' . htmlspecialchars($userName) . '</span>';
+            $html .= '<small>' . htmlspecialchars($context['element']->getExcerpt(0, 100)) . '</small></a>';
             $html .= '</div>';
 
             return $html;


### PR DESCRIPTION
Stop guests/users from commenting HTML and then it being rendered in the comment admin section.